### PR TITLE
Possible fix applied to condition to display badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,9 @@
                     <atomic-field-condition must-match-sourcetype="Salesforce">
                       <atomic-result-badge label="Salesforce" class="salesforce-badge"></atomic-result-badge>
                     </atomic-field-condition>
-                    <atomic-result-badge field="language" icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"></atomic-result-badge>
+                    <atomic-field-condition class="field" if-defined="language">
+                      <atomic-result-badge icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg"></atomic-result-badge>
+                    </atomic-field-condition>
                   </atomic-result-section-badges>
                   <atomic-result-section-title><atomic-result-link></atomic-result-link></atomic-result-section-title>
                   <atomic-result-section-title-metadata>
@@ -287,7 +289,7 @@
                     <atomic-result-text field="source"></atomic-result-text>
                   </atomic-table-element>
                   <atomic-table-element label="language">
-                    <atomic-result-text field="language"></atomic-result-text>
+                    <atomic-result-multi-value-text field="language"></atomic-result-multi-value-text>
                   </atomic-table-element>
                   <atomic-table-element label="file-type">
                     <atomic-result-text field="filetype"></atomic-result-text>


### PR DESCRIPTION
Jira: https://coveord.atlassian.net/browse/DOC-12576

The errors was being caused by atomic-result-badge component used to display the language badge. It appeared to be using the field property to detect whether the language field was defined.
It was replaced by an atomic-field-condition component.

Tested locally and on sandbox