### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/createNewAtomicSandBoxDemo.yml
+++ b/.github/workflows/createNewAtomicSandBoxDemo.yml
@@ -2,6 +2,8 @@ name: Create New CodeSandBoxDemo
 on:
   repository_dispatch:
     types: [atomic_docs_generated]
+permissions:
+  contents: write
 jobs:
   create-new-version-demo:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/coveo/atomic-documentation-codesandbox/security/code-scanning/2](https://github.com/coveo/atomic-documentation-codesandbox/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token scopes are declared and limited.  
For this specific workflow, the job checks out code and pushes a branch, so it needs `contents: write`. No other explicit scopes are required by the shown steps.

Best fix (without changing behavior): add a root-level `permissions:` block directly under `on:` (or under `name:` before `jobs:`) with:

- `contents: write`

This preserves existing functionality (`git push`) while removing implicit default permission behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
